### PR TITLE
Allow reference to specified container name

### DIFF
--- a/AzureStorageWagon/src/main/java/com/gkatzioura/maven/cloud/abs/AzureStorageRepository.java
+++ b/AzureStorageWagon/src/main/java/com/gkatzioura/maven/cloud/abs/AzureStorageRepository.java
@@ -66,7 +66,7 @@ public class AzureStorageRepository {
         String connectionString = connectionStringFactory.create(authenticationInfo);
         try {
             CloudStorageAccount cloudStorageAccount = CloudStorageAccount.parse(connectionString);
-            blobContainer = cloudStorageAccount.createCloudBlobClient().getContainerReference("snapshot");
+            blobContainer = cloudStorageAccount.createCloudBlobClient().getContainerReference(container);
             blobContainer.getMetadata();
         } catch (URISyntaxException |InvalidKeyException |StorageException e) {
             throw new AuthenticationException("Provide valid credentials");


### PR DESCRIPTION
The Azure Storage Wagon has a hard-coded reference to the `snapshot` container. This pull request uses the container parameter specified in the constructor.