### PR TITLE
allow region to be configured in settings.xml servers section

### DIFF
--- a/S3StorageWagon/src/main/java/com/gkatzioura/maven/cloud/s3/S3StorageRepository.java
+++ b/S3StorageWagon/src/main/java/com/gkatzioura/maven/cloud/s3/S3StorageRepository.java
@@ -63,16 +63,16 @@ public class S3StorageRepository {
         this.baseDirectory = baseDirectory;
     }
 
-    public void connect(AuthenticationInfo authenticationInfo) throws AuthenticationException {
+    public void connect(AuthenticationInfo authenticationInfo, String region) throws AuthenticationException {
 
         try {
-            Optional<String> region = new RegionProperty().get();
-
-            AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard().withCredentials(credentialsFactory.create(authenticationInfo));
-
-            if(region.isPresent()) {
-                builder.withRegion(region.get());
+            Optional<String> regionProperty = new RegionProperty().get();
+            if (region == null && regionProperty.isPresent()) {
+            	region = regionProperty.get();
             }
+
+            AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard().withCredentials(credentialsFactory.create(authenticationInfo))
+            		.withRegion(region);
 
             amazonS3 = builder.build();
             amazonS3.listBuckets();

--- a/S3StorageWagon/src/main/java/com/gkatzioura/maven/cloud/s3/S3StorageWagon.java
+++ b/S3StorageWagon/src/main/java/com/gkatzioura/maven/cloud/s3/S3StorageWagon.java
@@ -40,6 +40,8 @@ import com.gkatzioura.maven.cloud.wagon.AbstractStorageWagon;
 public class S3StorageWagon extends AbstractStorageWagon {
 
     private S3StorageRepository s3StorageRepository;
+    
+    private String region;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(S3StorageWagon.class);
 
@@ -126,9 +128,8 @@ public class S3StorageWagon extends AbstractStorageWagon {
         final String directory = containerResolver.resolve(repository);
 
         LOGGER.debug("Opening connection for bucket {} and directory {}",bucket,directory);
-
         s3StorageRepository = new S3StorageRepository(bucket,directory);
-        s3StorageRepository.connect(authenticationInfo);
+        s3StorageRepository.connect(authenticationInfo, region);
 
         sessionListenerContainer.fireSessionLoggedIn();
         sessionListenerContainer.fireSessionOpened();
@@ -141,5 +142,13 @@ public class S3StorageWagon extends AbstractStorageWagon {
         sessionListenerContainer.fireSessionLoggedOff();
         sessionListenerContainer.fireSessionDisconnected();
     }
+
+	public String getRegion() {
+		return region;
+	}
+
+	public void setRegion(String region) {
+		this.region = region;
+	}
 
 }


### PR DESCRIPTION
This change allows users to configure the region in settings.xml.  An example of how to configure the region is below...

```
<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
                      https://maven.apache.org/xsd/settings-1.0.0.xsd">

  <servers>
    <server>
      <id>my-s3-snapshot</id>
      <username>testuser</username>
      <password>xxxxxxx</password>
      <configuration>
        <region>us-west-2</region>
      </configuration>
    </server>
  </servers>

</settings>
```