### PR TITLE
Modify to support s3 download of directories

### DIFF
--- a/CloudStorageCore/src/main/java/com/gkatzioura/maven/cloud/resolver/KeyResolver.java
+++ b/CloudStorageCore/src/main/java/com/gkatzioura/maven/cloud/resolver/KeyResolver.java
@@ -18,25 +18,25 @@ package com.gkatzioura.maven.cloud.resolver;
 
 public class KeyResolver {
 
-    public String resolve(String... paths) {
+    public String resolve(String base, String path) {
+        return stripStartingSlash(combine(base, path));
+    }
 
-        StringBuilder builder = new StringBuilder();
+    private String combine(String base, String path) {
+        path = stripStartingSlash(path);
 
-        for(String s : paths) {
-
-            if(s.startsWith("/")) s = s.replaceFirst("/","");
-            builder.append(s);
-            if(!s.isEmpty() && !s.endsWith("/")) builder.append("/");
+        if(base.endsWith("/")) {
+            return base + path;
+        } else {
+            return base + "/" + path;
         }
-
-        return replaceLast(builder);
     }
 
-    private String replaceLast(StringBuilder stringBuilder) {
-        stringBuilder.replace(stringBuilder.lastIndexOf("/"), stringBuilder.lastIndexOf("/") + 1, "" );
-        return stringBuilder.toString();
+    private String stripStartingSlash(String path) {
+        if(path.startsWith("/")) {
+            return path.replaceFirst("/", "");
+        } else {
+            return path;
+        }
     }
-
-
-
 }

--- a/CloudStorageCore/src/test/java/com/gkatzioura/maven/cloud/transfer/KeyResolverTest.java
+++ b/CloudStorageCore/src/test/java/com/gkatzioura/maven/cloud/transfer/KeyResolverTest.java
@@ -28,23 +28,14 @@ public class KeyResolverTest {
 
         KeyResolver keyResolver = new KeyResolver();
         String directoryJoin = keyResolver.resolve("/t/","/tesanother/key/");
-        Assert.assertEquals("t/tesanother/key", directoryJoin);
+        Assert.assertEquals("t/tesanother/key/", directoryJoin);
     }
 
     @Test
     public void resolveEmptyBaseDirectory() {
-
         KeyResolver keyResolver = new KeyResolver();
         String directoryJoin = keyResolver.resolve("","/tesanother/key/");
-        Assert.assertEquals("tesanother/key", directoryJoin);
-    }
-
-    @Test
-    public void testResolveSimple() {
-
-        KeyResolver keyResolver = new KeyResolver();
-        String directoryJoin = keyResolver.resolve("/tesanother/key/");
-        Assert.assertEquals("tesanother/key", directoryJoin);
+        Assert.assertEquals("tesanother/key/", directoryJoin);
     }
 
     @Test

--- a/S3StorageWagon/src/main/java/com/gkatzioura/maven/cloud/s3/CredentialsFactory.java
+++ b/S3StorageWagon/src/main/java/com/gkatzioura/maven/cloud/s3/CredentialsFactory.java
@@ -19,6 +19,7 @@ package com.gkatzioura.maven.cloud.s3;
 import org.apache.maven.wagon.authentication.AuthenticationInfo;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSCredentialsProviderChain;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
@@ -26,10 +27,15 @@ import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 public class CredentialsFactory {
 
     public AWSCredentialsProvider create(AuthenticationInfo authenticationInfo) {
-        if(authenticationInfo==null) {
-            return new DefaultAWSCredentialsProviderChain();
+        if(authenticationInfo != null && authenticationInfo.getUserName() != null && authenticationInfo.getPassword() != null) {
+            return new AWSCredentialsProviderChain(
+                    new AWSStaticCredentialsProvider(
+                            new BasicAWSCredentials(
+                                    authenticationInfo.getUserName(),
+                                    authenticationInfo.getPassword())),
+                    new DefaultAWSCredentialsProviderChain());
         } else {
-            return new AWSStaticCredentialsProvider(new BasicAWSCredentials(authenticationInfo.getUserName(),authenticationInfo.getPassword()));
+            return new DefaultAWSCredentialsProviderChain();
         }
     }
 }


### PR DESCRIPTION
I needed to download files from s3 (I now see that mentioned in #13 as a possible additional feature), and looked to use this S3 Wagon with Codehaus's wagon-maven-plugin.

An example of the sort of config I was using is:

```xml
<plugin>
  <groupId>org.codehaus.mojo</groupId>
  <artifactId>wagon-maven-plugin</artifactId>
  <version>2.0.0</version>
  <executions>
    <execution>
      <id>default-cli</id>
      <goals>
        <goal>download</goal>
      </goals>
      <configuration>
        <url>s3://bucket-name/prefix</url>
        <toDir>${project.basedir}</toDir>
        <includes>**</includes>
      </configuration>
    </execution>
  </executions>
</plugin>
```

(The intent here was to "overlay" files from the bucket on the repository, for certain sensitive config files).

While trying this I came across a few minor incompatibilities between how the S3 Wagon works and how wagon-maven-plugin needs it to work. This PR addresses those (as well as slightly tweaking how auth works). I'll put comments at a few places in the PR for extra explanation.