### PR TITLE
feat(s3): support alternative S3 endpoints and path style S3 resolution

### DIFF
--- a/S3StorageWagon/pom.xml
+++ b/S3StorageWagon/pom.xml
@@ -5,6 +5,7 @@
         <groupId>com.gkatzioura.maven.cloud</groupId>
         <version>1.6-SNAPSHOT</version>
     </parent>
+    <version>1.7</version>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>s3-storage-wagon</artifactId>
@@ -12,6 +13,7 @@
 
     <properties>
         <aws-s3.version>1.11.418</aws-s3.version>
+        <httpcore>4.4.10</httpcore>
     </properties>
 
     <licenses>
@@ -21,7 +23,6 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.maven.wagon</groupId>
@@ -54,6 +55,11 @@
             <artifactId>maven-plugin-annotations</artifactId>
             <version>3.4</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>${httpcore}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/S3StorageWagon/src/main/java/com/gkatzioura/maven/cloud/s3/EndpointProperty.java
+++ b/S3StorageWagon/src/main/java/com/gkatzioura/maven/cloud/s3/EndpointProperty.java
@@ -16,36 +16,33 @@
 
 package com.gkatzioura.maven.cloud.s3;
 
-import com.amazonaws.regions.Regions;
 
-import java.util.Optional;
+public class EndpointProperty {
 
-public class RegionProperty {
-
-    private static final String AWS_DEFAULT_REGION_TAG = "AWS_DEFAULT_REGION";
-    private String region;
+    private static final String S3_ENDPOINT = "S3_ENDPOINT";
+    private String endpoint;
 
     /**
      *
-     * @param region may be null
+     * @param endpoint may be null
      */
-    public RegionProperty(String region){
+    public EndpointProperty(String endpoint){
 
-        this.region = region;
+        this.endpoint = endpoint;
     }
 
     /**
-     * return the region set in the constructor or the region set using the AWS_DEFAULT_REGION system property or the default AWS region (us_west_2)
+     * @return the endpoint set in the constructor or set using the S3_ENDPOINT system property or null
      * */
     public String get() {
-        if (region != null){
-            return region;
+        if (endpoint != null){
+            return endpoint;
         }
-        String regionEnv = System.getProperty("AWS_DEFAULT_REGION");
-        if(regionEnv==null) {
-            return regionEnv;
+        String endpointEnv = System.getProperty(S3_ENDPOINT);
+        if(endpointEnv != null) {
+            return endpointEnv;
         }
-        return Regions.DEFAULT_REGION.getName();
+        return null;
     }
 
 }

--- a/S3StorageWagon/src/main/java/com/gkatzioura/maven/cloud/s3/PathStyleEnabledProperty.java
+++ b/S3StorageWagon/src/main/java/com/gkatzioura/maven/cloud/s3/PathStyleEnabledProperty.java
@@ -16,36 +16,33 @@
 
 package com.gkatzioura.maven.cloud.s3;
 
-import com.amazonaws.regions.Regions;
 
-import java.util.Optional;
+public class PathStyleEnabledProperty {
 
-public class RegionProperty {
-
-    private static final String AWS_DEFAULT_REGION_TAG = "AWS_DEFAULT_REGION";
-    private String region;
+    private static final String PATH_STYLE_PROP = "S3_PATH_STYLE_ENABLED";
+    private String pathStyleEnabled;
 
     /**
      *
-     * @param region may be null
+     * @param pathStyleEnabled may be null
      */
-    public RegionProperty(String region){
+    public PathStyleEnabledProperty(String pathStyleEnabled){
 
-        this.region = region;
+        this.pathStyleEnabled = pathStyleEnabled;
     }
 
     /**
-     * return the region set in the constructor or the region set using the AWS_DEFAULT_REGION system property or the default AWS region (us_west_2)
+     * @return the pathStyle set in the constructor or set using the S3_PATH_STYLE_ENABLED system property or false
      * */
-    public String get() {
-        if (region != null){
-            return region;
+    public boolean get() {
+        if (pathStyleEnabled != null){
+            return Boolean.valueOf(pathStyleEnabled);
         }
-        String regionEnv = System.getProperty("AWS_DEFAULT_REGION");
-        if(regionEnv==null) {
-            return regionEnv;
+        String pathStyleEnv = System.getProperty(PATH_STYLE_PROP);
+        if(pathStyleEnv != null) {
+            return Boolean.valueOf(pathStyleEnv);
         }
-        return Regions.DEFAULT_REGION.getName();
+        return false;
     }
 
 }

--- a/S3StorageWagon/src/main/java/com/gkatzioura/maven/cloud/s3/RegionProperty.java
+++ b/S3StorageWagon/src/main/java/com/gkatzioura/maven/cloud/s3/RegionProperty.java
@@ -16,18 +16,23 @@
 
 package com.gkatzioura.maven.cloud.s3;
 
+import com.amazonaws.regions.Regions;
+
 import java.util.Optional;
 
 public class RegionProperty {
 
     private static final String AWS_DEFAULT_REGION_TAG = "AWS_DEFAULT_REGION";
 
+    /**
+     * return the region set using  the AWS_DEFAULT_REGION system property or the default AWS region (us_west_2)
+     * */
     public Optional<String> get() {
 
         String region = System.getProperty("AWS_DEFAULT_REGION");
 
         if(region==null) {
-            return Optional.empty();
+            return Optional.of(Regions.DEFAULT_REGION.getName());
         }
 
         return Optional.of(region);

--- a/S3StorageWagon/src/main/java/com/gkatzioura/maven/cloud/s3/RegionProperty.java
+++ b/S3StorageWagon/src/main/java/com/gkatzioura/maven/cloud/s3/RegionProperty.java
@@ -42,7 +42,7 @@ public class RegionProperty {
             return region;
         }
         String regionEnv = System.getProperty("AWS_DEFAULT_REGION");
-        if(regionEnv==null) {
+        if(regionEnv != null) {
             return regionEnv;
         }
         return Regions.DEFAULT_REGION.getName();

--- a/S3StorageWagon/src/main/java/com/gkatzioura/maven/cloud/s3/S3StorageRepository.java
+++ b/S3StorageWagon/src/main/java/com/gkatzioura/maven/cloud/s3/S3StorageRepository.java
@@ -69,27 +69,21 @@ public class S3StorageRepository {
         this.baseDirectory = baseDirectory;
     }
 
-    public void connect(AuthenticationInfo authenticationInfo, String region) throws AuthenticationException {
+    public void connect(AuthenticationInfo authenticationInfo, RegionProperty region, EndpointProperty endpoint, PathStyleEnabledProperty pathStyle) throws AuthenticationException {
         AmazonS3ClientBuilder builder = null;
         try {
             final Optional<String> regionOpt;
-            if (region != null) {
-                regionOpt = Optional.of(region);
-            } else {
-                regionOpt = new RegionProperty().get();
-            }
 
             builder = AmazonS3ClientBuilder.standard().withCredentials(credentialsFactory.create(authenticationInfo));
 
-            String endpoint = System.getProperty("S3_ENDPOINT", null);
-            if (endpoint != null){
-                builder.setEndpointConfiguration( new AwsClientBuilder.EndpointConfiguration(endpoint, regionOpt.get()));
+            if (endpoint.get() != null){
+                builder.setEndpointConfiguration( new AwsClientBuilder.EndpointConfiguration(endpoint.get(), region.get()));
             }else {
-                builder.withRegion(regionOpt.get());
+                builder.withRegion(region.get());
             }
 
 
-            builder.setPathStyleAccessEnabled(Boolean.getBoolean("S3_PATH_STYLE_ENABLED"));
+            builder.setPathStyleAccessEnabled(pathStyle.get());
 
             amazonS3 = builder.build();
             amazonS3.listBuckets();

--- a/S3StorageWagon/src/main/java/com/gkatzioura/maven/cloud/s3/S3StorageWagon.java
+++ b/S3StorageWagon/src/main/java/com/gkatzioura/maven/cloud/s3/S3StorageWagon.java
@@ -44,6 +44,8 @@ public class S3StorageWagon extends AbstractStorageWagon {
     private String region;
 
     private static final Logger LOGGER = Logger.getLogger(S3StorageWagon.class.getName());
+    private String endpoint;
+    private String pathStyleEnabled;
 
     @Override
     public void get(String resourceName, File file) throws TransferFailedException, ResourceDoesNotExistException, AuthorizationException {
@@ -129,7 +131,7 @@ public class S3StorageWagon extends AbstractStorageWagon {
 
         LOGGER.log(Level.FINER,String.format("Opening connection for bucket %s and directory %s",bucket,directory));
         s3StorageRepository = new S3StorageRepository(bucket,directory);
-        s3StorageRepository.connect(authenticationInfo, region);
+        s3StorageRepository.connect(authenticationInfo, new RegionProperty(region), new EndpointProperty(endpoint), new PathStyleEnabledProperty(pathStyleEnabled));
 
         sessionListenerContainer.fireSessionLoggedIn();
         sessionListenerContainer.fireSessionOpened();
@@ -150,5 +152,21 @@ public class S3StorageWagon extends AbstractStorageWagon {
 	public void setRegion(String region) {
 		this.region = region;
 	}
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public String getPathStyleAccessEnabled() {
+        return pathStyleEnabled;
+    }
+
+    public void setPathStyleAccessEnabled(String pathStyleEnabled) {
+        this.pathStyleEnabled = pathStyleEnabled;
+    }
 
 }


### PR DESCRIPTION
S3 API has become very popular and other providers than AWS also are compatible with S3 APIs.
* To make it compatible with such service/server like [Minio](https://minio.io/) I have update the maven S3 wagon to cope with alternative S3 endpoints.
* I have also fixed a dependency issue with some classes missing see https://github.com/awsdocs/aws-doc-sdk-examples/issues/354
* I have also set the region to the AWS default region if not provided and provided a more meaningful error message and less brittle than relying on the exception message. 