### PR TITLE
Update Google Storage Dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,8 @@ fabric.properties
 
 .idea
 *.iml
+
+# VSCode / Eclipse
+.settings/
+.project
+.classpath

--- a/GoogleStorageWagon/pom.xml
+++ b/GoogleStorageWagon/pom.xml
@@ -11,7 +11,7 @@
     <description>Google Cloud storage wagon</description>
 
     <properties>
-        <gcs.version>1.20.0</gcs.version>
+        <gcs.version>1.56.0</gcs.version>
     </properties>
 
     <licenses>


### PR DESCRIPTION
I have a conflict when using the wagon with Sonar maven plugin.
I found that it was related to the version of commons-codec.
Updating the Google Cloud Storage Dependency to its last version would use commons-codec 1.10 instead of commons-codec 1.3 and that fixes my issue.
