### PR TITLE
Set content type for azure blob storage and fix issue with multimodule projects

### DIFF
--- a/AzureStorageWagon/src/main/java/com/gkatzioura/maven/cloud/abs/AzureStorageRepository.java
+++ b/AzureStorageWagon/src/main/java/com/gkatzioura/maven/cloud/abs/AzureStorageRepository.java
@@ -120,6 +120,7 @@ public class AzureStorageRepository {
         try {
 
             CloudBlockBlob blob = blobContainer.getBlockBlobReference(destination);
+            blob.getProperties().setContentType(getContentType(file));
 
             try(InputStream inputStream = new TransferProgressFileInputStream(file,transferProgress)) {
                 blob.upload(inputStream,-1);
@@ -127,6 +128,29 @@ public class AzureStorageRepository {
         } catch (URISyntaxException |StorageException | IOException e) {
             LOGGER.log(Level.SEVERE,"Could not fetch cloud blob",e);
             throw new TransferFailedException(destination);
+        }
+    }
+
+    private String getContentType(File file) {
+        String name = file.getName().toLowerCase();
+        if (name.endsWith(".txt")) {
+            return "text/plain";
+        } else if (name.endsWith(".js")) {
+            return "text/javascript";
+        } else if (name.endsWith(".css")) {
+            return "text/css";
+        } else if (name.endsWith(".htm") || name.endsWith(".html")) {
+            return "text/html";
+        } else if (name.endsWith(".json")) {
+            return "application/json";
+        } else if (name.endsWith(".jpg") || name.endsWith(".jpeg")) {
+            return "image/jpeg";
+        } else if (name.endsWith(".png")) {
+            return "image/png";
+        } else if (name.endsWith(".gif")) {
+            return "image/gif";
+        } else {
+            return "application/octet-stream";
         }
     }
 

--- a/AzureStorageWagon/src/main/java/com/gkatzioura/maven/cloud/abs/AzureStorageWagon.java
+++ b/AzureStorageWagon/src/main/java/com/gkatzioura/maven/cloud/abs/AzureStorageWagon.java
@@ -17,6 +17,7 @@
 package com.gkatzioura.maven.cloud.abs;
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -81,8 +82,7 @@ public class AzureStorageWagon extends AbstractStorageWagon {
 
     @Override
     public void put(File file, String resourceName) throws TransferFailedException, ResourceDoesNotExistException, AuthorizationException {
-
-        resourceName = FilenameUtils.normalize(resourceName, true);
+        resourceName = Paths.get(resourceName).normalize().toString();
         Resource resource = new Resource(resourceName);
 
         LOGGER.log(Level.FINER, String.format("Uploading file %s to %s", file.getAbsolutePath(), resourceName));


### PR DESCRIPTION
- Set content type for azure blob storage. Without content type set website hosting (see https://azure.microsoft.com/en-us/blog/azure-storage-static-web-hosting-public-preview/) doesn't work correct (browser download all files, including .html instead display it).
- Change normalization to support multimodule projects. In multimodule project resourseName starts with double dot (e.g. ../moduleName). FilenameUtils.normalize converts such paths to null and causes NPE.