### PR TITLE
remove `listBuckets` call when instantiating the S3 client

### DIFF
--- a/S3StorageWagon/src/main/java/com/gkatzioura/maven/cloud/s3/S3StorageRepository.java
+++ b/S3StorageWagon/src/main/java/com/gkatzioura/maven/cloud/s3/S3StorageRepository.java
@@ -90,7 +90,6 @@ public class S3StorageRepository {
             builder = createAmazonS3ClientBuilder(authenticationInfo, region, endpoint, pathStyle);
 
             amazonS3 = builder.build();
-            amazonS3.listBuckets();
 
             LOGGER.log(Level.FINER,String.format("Connected to s3 using bucket %s with base directory %s",bucket,baseDirectory));
 


### PR DESCRIPTION
`listBuckets` requires extended S3 permissions that doesn't seem needed for the plugin to work.

Furthermore, the result of `amazonS3.listBuckets();` does not seem to be used by anything.