### PR TITLE
Fixes #48 - Set content length on put to S3 repository

### DIFF
--- a/S3StorageWagon/src/main/java/com/gkatzioura/maven/cloud/s3/S3StorageRepository.java
+++ b/S3StorageWagon/src/main/java/com/gkatzioura/maven/cloud/s3/S3StorageRepository.java
@@ -152,7 +152,7 @@ public class S3StorageRepository {
 
         try {
             try(InputStream inputStream = new TransferProgressFileInputStream(file,transferProgress)) {
-                PutObjectRequest putObjectRequest = new PutObjectRequest(bucket,key,inputStream,new ObjectMetadata());
+                PutObjectRequest putObjectRequest = new PutObjectRequest(bucket,key,inputStream,createContentLengthMetadata(file));
                 applyPublicRead(putObjectRequest);
                 amazonS3.putObject(putObjectRequest);
             }
@@ -160,6 +160,12 @@ public class S3StorageRepository {
             LOGGER.log(Level.SEVERE,"Could not transfer file ",e);
             throw new TransferFailedException("Could not transfer file "+file.getName());
         }
+    }
+
+    private ObjectMetadata createContentLengthMetadata(File file) {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(file.length());
+        return metadata;
     }
 
     public boolean newResourceAvailable(String resourceName,long timeStamp) throws ResourceDoesNotExistException {


### PR DESCRIPTION
Setting content length on upload to S3 to avoid warning about unknown content length.

I have tested this locally and verified that uploaded files are still correct. I am personally not aware of any corner cases where the content length (file size) would be missing or invalid but you might have more input on this.