### PR TITLE
 Allow configuring the target bucket's region as a parameter passed to the s3-upload goal

### DIFF
--- a/S3StorageWagon/README.md
+++ b/S3StorageWagon/README.md
@@ -49,7 +49,7 @@ PUBLIC_REPOSITORY=true mvn deploy
 
 Then you can use the artifact without any authorised access
 
-```bash
+```xml
     <repositories>
         <repository>
             <id>bucket-repo</id>
@@ -61,111 +61,133 @@ Then you can use the artifact without any authorised access
 ## Upload/download files for ci/cd purposes
 
 Apart from giving a solution to use s3 a maven repository the storage s3-storage-wagon can be used as a plugin in order to
-upload and download items from s3. 
+upload and download any items from s3.
 
-###### Upload files
+### Configuration
+Note that the configuration set for servers and repositories does not apply to this mode of operation.
+
+#### Authentication
+Authentication must be passed by the environment. See the
+<a href="https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html">AWS S3 API documentation</a>
+for a description of all locations where such configuration can be set.
+
+A simple way to configure this is to define the username and password as Properties available to the maven environment:
+```xml
+<properties>
+    <aws.accessKeyid>access_key</aws.accessKeyid>
+    <aws.secretKey>access_secret</aws.secretKey>
+</properties>
+```
+
+Alternatively, you may pick any of the other methods mentioned in the link above (e.g., defining the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables).
+
+
+### Upload files
 
 ```xml
 <build>
-        <plugins>
-            <plugin>
-                <groupId>com.gkatzioura.maven.cloud</groupId>
-                <artifactId>s3-storage-wagon</artifactId>
-                <version>1.5-SNAPSHOT</version>
-                <executions>
-                    <execution>
-                        <id>upload-single-file</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>s3-upload</goal>
-                        </goals>
-                        <configuration>
-                            <bucket>yourbucketname</bucket>
-                            <path>/file/path/test.txt</path>
-                            <key>test.txt</key>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>upload-multiple-files</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>s3-upload</goal>
-                        </goals>
-                        <configuration>
-                            <bucket>yourbucketname</bucket>
-                            <path>/path/to/directory/with/files</path>
-                            <key>prefixforfiles</key>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>upload-single-file-no-key</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>s3-upload</goal>
-                        </goals>
-                        <configuration>
-                            <bucket>yourbucketname</bucket>
-                            <path>/file/path/test.txt</path>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+    <plugins>
+        <plugin>
+            <groupId>com.gkatzioura.maven.cloud</groupId>
+            <artifactId>s3-storage-wagon</artifactId>
+            <version>1.5-SNAPSHOT</version>
+            <executions>
+                <execution>
+                    <id>upload-single-file</id>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>s3-upload</goal>
+                    </goals>
+                    <configuration>
+                        <bucket>yourbucketname</bucket>
+                        <region>yourbucket-region</region>
+                        <path>/file/path/test.txt</path>
+                        <key>test.txt</key>
+                    </configuration>
+                </execution>
+                <execution>
+                    <id>upload-multiple-files</id>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>s3-upload</goal>
+                    </goals>
+                    <configuration>
+                        <bucket>yourbucketname</bucket>
+                        <region>yourbucket-region</region>
+                        <path>/path/to/directory/with/files</path>
+                        <key>prefixforfiles</key>
+                    </configuration>
+                </execution>
+                <execution>
+                    <id>upload-single-file-no-key</id>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>s3-upload</goal>
+                    </goals>
+                    <configuration>
+                        <bucket>yourbucketname</bucket>
+                        <region>yourbucket-region</region>
+                        <path>/file/path/test.txt</path>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
+    </plugins>
+</build>
 ```
 
-###### Download files
+### Download files
 
 ```xml
- <build>
-        <plugins>
-            <plugin>
-                <groupId>com.gkatzioura.maven.cloud</groupId>
-                <artifactId>s3-storage-wagon</artifactId>
-                <version>1.5-SNAPSHOT</version>
-                <executions>
-                    <execution>
-                        <id>download-multiple-files-to-one-directory</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>s3-download</goal>
-                        </goals>
-                        <configuration>
-                            <bucket>yourbucketname</bucket>
-                            <downloadPath>/path/to/directory</downloadPath>
-                            <keys>file1.txt,file2.jpg</keys>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>download-files-and-files-starting-with-prefix</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>s3-download</goal>
-                        </goals>
-                        <configuration>
-                            <bucket>yourbucketname</bucket>
-                            <downloadPath>/path/to/directory</downloadPath>
-                            <keys>prefix,file1.txt,file2.txt</keys>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>download-single-file</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>s3-download</goal>
-                        </goals>
-                        <configuration>
-                            <bucket>yourbucketname</bucket>
-                            <downloadPath>/path/to/directory/file.txt</downloadPath>
-                            <keys>file-to-download.txt</keys>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
- </build>   
+<build>
+    <plugins>
+        <plugin>
+            <groupId>com.gkatzioura.maven.cloud</groupId>
+            <artifactId>s3-storage-wagon</artifactId>
+            <version>1.5-SNAPSHOT</version>
+            <executions>
+                <execution>
+                    <id>download-multiple-files-to-one-directory</id>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>s3-download</goal>
+                    </goals>
+                    <configuration>
+                        <bucket>yourbucketname</bucket>
+                        <downloadPath>/path/to/directory</downloadPath>
+                        <keys>file1.txt,file2.jpg</keys>
+                    </configuration>
+                </execution>
+                <execution>
+                    <id>download-files-and-files-starting-with-prefix</id>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>s3-download</goal>
+                    </goals>
+                    <configuration>
+                        <bucket>yourbucketname</bucket>
+                        <downloadPath>/path/to/directory</downloadPath>
+                        <keys>prefix,file1.txt,file2.txt</keys>
+                    </configuration>
+                </execution>
+                <execution>
+                    <id>download-single-file</id>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>s3-download</goal>
+                    </goals>
+                    <configuration>
+                        <bucket>yourbucketname</bucket>
+                        <downloadPath>/path/to/directory/file.txt</downloadPath>
+                        <keys>file-to-download.txt</keys>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
+    </plugins>
+</build>
 ```
 
-Full guide on upload [download](https://egkatzioura.com/2019/01/22/upload-and-download-files-to-s3-using-maven/)
+Full guide on [upload and download](https://egkatzioura.com/2019/01/22/upload-and-download-files-to-s3-using-maven/).
 
 

--- a/S3StorageWagon/src/main/java/com/gkatzioura/maven/cloud/s3/CredentialsFactory.java
+++ b/S3StorageWagon/src/main/java/com/gkatzioura/maven/cloud/s3/CredentialsFactory.java
@@ -25,6 +25,18 @@ import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 
 public class CredentialsFactory {
 
+    /**
+     * Creates an {@link AWSCredentialsProvider} from the passed {@link AuthenticationInfo}. This should contain the
+     * username and password used to authenticate when connecting to AWS .<br/>
+     * When {@code authenticationInfo} is passed as {@code null}, a {@link DefaultAWSCredentialsProviderChain} will be
+     * used. This is an authentication provider that gets the credentials from Java environment properties, system
+     * environment variables or other global locations. See the {@link DefaultAWSCredentialsProviderChain} documentation
+     * for details.
+     *
+     * @param authenticationInfo an {@link AuthenticationInfo} containing the AWS credentials to use
+     * @return a newly-built {@link AWSCredentialsProvider} with the credentials associated to the passed
+     *         {@code authenticationInfo}
+     */
     public AWSCredentialsProvider create(AuthenticationInfo authenticationInfo) {
         if(authenticationInfo==null) {
             return new DefaultAWSCredentialsProviderChain();

--- a/S3StorageWagon/src/main/java/com/gkatzioura/maven/cloud/s3/utils/S3Connect.java
+++ b/S3StorageWagon/src/main/java/com/gkatzioura/maven/cloud/s3/utils/S3Connect.java
@@ -32,6 +32,8 @@ public class S3Connect {
     private static final Logger LOGGER = Logger.getLogger(S3Connect.class.getName());
 
     /**
+     * Connects to the AWS API. The provided authentication, region, endpoint and path-style are all taken into account
+     * to create the returned {@link AmazonS3} instance.
      *
      * @param authenticationInfo When {@code authenticationInfo} is passed as {@code null}, an authentication provider
      *                           that gets the credentials from environment properties, system environment variables or
@@ -43,8 +45,8 @@ public class S3Connect {
      * @param pathStyle A {@link PathStyleEnabledProperty} indicating whether the endpoint/bucket configuration being
      *                  passed is in a path-style configuration. See
      *                  <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro">Accessing a Bucket in the S3 documentation</a>.
-     * @return
-     * @throws AuthenticationException
+     * @return An instance of {@link AmazonS3} that can be used to send and receive data to the intended endpoint/bucket.
+     * @throws AuthenticationException if the passed credentials are invalid for connecting to the intended endpoint/bucket.
      */
     public static AmazonS3 connect(AuthenticationInfo authenticationInfo, String region, EndpointProperty endpoint, PathStyleEnabledProperty pathStyle) throws AuthenticationException {
         AmazonS3ClientBuilder builder = null;

--- a/S3StorageWagon/src/main/java/com/gkatzioura/maven/cloud/s3/utils/S3Connect.java
+++ b/S3StorageWagon/src/main/java/com/gkatzioura/maven/cloud/s3/utils/S3Connect.java
@@ -1,0 +1,92 @@
+/*
+ * The copyright of this file belongs to Feedzai. The file cannot be
+ * reproduced in whole or in part, stored in a retrieval system,
+ * transmitted in any form, or by any means electronic, mechanical,
+ * photocopying, or otherwise, without the prior permission of the owner.
+ *
+ * © 2019 Feedzai, Strictly Confidential
+ */
+package com.gkatzioura.maven.cloud.s3.utils;
+
+import com.amazonaws.SdkClientException;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.gkatzioura.maven.cloud.s3.CredentialsFactory;
+import com.gkatzioura.maven.cloud.s3.EndpointProperty;
+import com.gkatzioura.maven.cloud.s3.PathStyleEnabledProperty;
+import com.gkatzioura.maven.cloud.s3.S3StorageRegionProviderChain;
+import org.apache.maven.wagon.authentication.AuthenticationException;
+import org.apache.maven.wagon.authentication.AuthenticationInfo;
+
+import java.util.logging.Logger;
+
+/**
+ * Utility methods used to connect to Amazon's S3 API.
+ */
+public class S3Connect {
+
+    /**
+     * A logger for this class.
+     */
+    private static final Logger LOGGER = Logger.getLogger(S3Connect.class.getName());
+
+    /**
+     *
+     * @param authenticationInfo When {@code authenticationInfo} is passed as {@code null}, an authentication provider
+     *                           that gets the credentials from environment properties, system environment variables or
+     *                           other global locations will be used. See the documentation for the
+     *                           <a href="https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html">DefaultAWSCredentialsProviderChain</a>
+     *                           class for details.
+     * @param region    The region where the bucket was created in.
+     * @param endpoint  The endpoint/bucket to connect to.
+     * @param pathStyle A {@link PathStyleEnabledProperty} indicating whether the endpoint/bucket configuration being
+     *                  passed is in a path-style configuration. See
+     *                  <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro">Accessing a Bucket in the S3 documentation</a>.
+     * @return
+     * @throws AuthenticationException
+     */
+    public static AmazonS3 connect(AuthenticationInfo authenticationInfo, String region, EndpointProperty endpoint, PathStyleEnabledProperty pathStyle) throws AuthenticationException {
+        AmazonS3ClientBuilder builder = null;
+        try {
+            builder = createAmazonS3ClientBuilder(authenticationInfo, region, endpoint, pathStyle);
+
+            AmazonS3 amazonS3 = builder.build();
+
+            LOGGER.finer(String.format("Connected to S3 using bucket %s.", endpoint.get()));
+
+            return amazonS3;
+        } catch (SdkClientException e) {
+            if (builder != null){
+                StringBuilder message = new StringBuilder();
+                message.append("Failed to connect");
+                if (builder.getEndpoint() != null){
+                    message.append(
+                            String.format(" to endpoint [%s] using region [%s]",
+                                    builder.getEndpoint().getServiceEndpoint(),
+                                    builder.getEndpoint().getSigningRegion()));
+
+                } else {
+                    message.append(String.format(" using region [%s]", builder.getRegion()));
+                }
+                throw new AuthenticationException(message.toString(), e);
+            }
+            throw new AuthenticationException("Could not authenticate", e);
+        }
+    }
+
+    private static AmazonS3ClientBuilder createAmazonS3ClientBuilder(AuthenticationInfo authenticationInfo, String region, EndpointProperty endpoint, PathStyleEnabledProperty pathStyle) {
+        final S3StorageRegionProviderChain regionProvider = new S3StorageRegionProviderChain(region);
+
+        AmazonS3ClientBuilder builder;
+        builder = AmazonS3ClientBuilder.standard().withCredentials(new CredentialsFactory().create(authenticationInfo));
+        builder.setRegion(regionProvider.getRegion());
+
+        if (endpoint.get() != null){
+            builder.setEndpointConfiguration( new AwsClientBuilder.EndpointConfiguration(endpoint.get(), builder.getRegion()));
+        }
+
+        builder.setPathStyleAccessEnabled(pathStyle.get());
+        return builder;
+    }
+}

--- a/S3StorageWagon/src/test/java/com/gkatzioura/maven/cloud/s3/S3StorageWagonTest.java
+++ b/S3StorageWagon/src/test/java/com/gkatzioura/maven/cloud/s3/S3StorageWagonTest.java
@@ -1,22 +1,17 @@
 package com.gkatzioura.maven.cloud.s3;
 
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
-import org.apache.maven.wagon.Wagon;
-import org.apache.maven.wagon.WagonConstants;
+import com.gkatzioura.maven.cloud.s3.utils.S3Connect;
 import org.apache.maven.wagon.WagonTestCase;
 import org.apache.maven.wagon.authentication.AuthenticationInfo;
 import org.apache.maven.wagon.repository.Repository;
 import org.apache.maven.wagon.resource.Resource;
-import org.junit.Test;
 
 import java.io.IOException;
-import java.net.URL;
 import java.util.Iterator;
-import java.util.List;
 
 /***
  * this class will launch 14 unit test from the apache wagon provider tester
@@ -60,8 +55,8 @@ public class S3StorageWagonTest extends WagonTestCase {
     protected void setUp() throws Exception {
         super.setUp();
         //creates the bucket
-        AmazonS3ClientBuilder amazonS3ClientBuilder = S3StorageRepository.createAmazonS3ClientBuilder(getAuthInfo(), null, new EndpointProperty(null), new PathStyleEnabledProperty(null));
-        amazonS3 = amazonS3ClientBuilder.build();
+        amazonS3 = S3Connect.connect(getAuthInfo(), null, new EndpointProperty(null), new PathStyleEnabledProperty(null));
+
         createBucket();
     }
 


### PR DESCRIPTION
It was noted that for the `s3-upload` goal:
  * AWS credentials must be available in the environment and are not
    configurable in the same way as for the release/snapshot/site repositories.
  * the bucket's region was only configurable through environment variables.

Thus, this change:
  1. documents (in the global README) how to configure credentials for the
     `s3-upload` goal through maven properties; and
  2. adds the ability to configure the target bucket's region as a configuration
     in the execution for the `s3-upload` goal.
     For example:
     ```xml
         <configuration>
         (...)
             <region>yourbucket-region</region>
         (...)
     ```