### PR TITLE
Azure: Support supplying custom connection strings

### DIFF
--- a/AzureStorageWagon/src/main/java/com/gkatzioura/maven/cloud/abs/ConnectionStringFactory.java
+++ b/AzureStorageWagon/src/main/java/com/gkatzioura/maven/cloud/abs/ConnectionStringFactory.java
@@ -33,7 +33,14 @@ public class ConnectionStringFactory {
             throw new AuthenticationException("Please provide storage account credentials");
         }
 
-        return String.format(CONNECTION_STRING_TEMPLATE,authenticationInfo.getUserName(),authenticationInfo.getPassword());
+        String username = authenticationInfo.getUserName();
+        String password = authenticationInfo.getPassword();
+
+        if (username == null || username.isEmpty()) {
+            return password;
+        } else {
+            return String.format(CONNECTION_STRING_TEMPLATE, username, password);
+        }
     }
 
     /**


### PR DESCRIPTION
Support for SAS: https://docs.microsoft.com/en-us/rest/api/storageservices/delegating-access-with-a-shared-access-signature

With username and password, the connection string will look like

```
DefaultEndpointsProtocol=https;AccountName=MYCONTAINERNAME;AccountKey=MYKEY;EndpointSuffix=core.windows.net
```

with SAS, the connection string will look like

```
BlobEndpoint=https://MY_SA_NAME.blob.core.windows.net/;QueueEndpoint=https://MY_SA_NAME.queue.core.windows.net/;FileEndpoint=https://MY_SA_NAME.file.core.windows.net/;TableEndpoint=https://MY_SA_NAME.table.core.windows.net/;SharedAccessSignature=sv=2018-03-28&amp;ss=bfqt&amp;srt=sco&amp;sp=rwdlacup&amp;se=2020-04-14T18:18:40Z&amp;st=2019-07-01T10:18:40Z&amp;spr=https&amp;sig=MY_SIGNATURE
```

Thanks for the project, it helps us a lot! 👍