### PR TITLE
We've run into an issue with the plugin. Version 1.7 works for us fin…

### DIFF
--- a/GoogleStorageWagon/src/main/java/com/gkatzioura/maven/cloud/gcs/wagon/GoogleStorageRepository.java
+++ b/GoogleStorageWagon/src/main/java/com/gkatzioura/maven/cloud/gcs/wagon/GoogleStorageRepository.java
@@ -46,7 +46,7 @@ public class GoogleStorageRepository {
     private final String baseDirectory;
     private final KeyResolver keyResolver = new KeyResolver();
     private final StorageFactory storageFactory = new StorageFactory();
-    private final Optional<String> keyPath;
+    private final Optional<String> keyPath = Optional.empty();
     private final PublicReadProperty publicReadProperty;
 
     private Storage storage;


### PR DESCRIPTION
…e but late latest fails with the following stack.

Aug 22, 2019 2:45:33 PM com.gkatzioura.maven.cloud.gcs.wagon.GoogleStorageRepository connect
SEVERE: Could not establish connection with google cloud
java.lang.NullPointerException
	at com.gkatzioura.maven.cloud.gcs.wagon.GoogleStorageRepository.createStorage(GoogleStorageRepository.java:74)
	at com.gkatzioura.maven.cloud.gcs.wagon.GoogleStorageRepository.connect(GoogleStorageRepository.java:65)
	at com.gkatzioura.maven.cloud.gcs.wagon.GoogleStorageWagon.connect(GoogleStorageWagon.java:139)
	at org.eclipse.aether.transport.wagon.WagonTransporter.connectWagon(WagonTransporter.java:342)

Removed the rest of the call stack for brevity.

Following change fixes the issue for us. Was hoping to get it adopted upstream.